### PR TITLE
MyComment Episode return

### DIFF
--- a/src/main/java/com/example/project/emotionCore/Repository/CommentRepository.java
+++ b/src/main/java/com/example/project/emotionCore/Repository/CommentRepository.java
@@ -1,9 +1,6 @@
 package com.example.project.emotionCore.Repository;
 
-import com.example.project.emotionCore.domain.Comment;
-import com.example.project.emotionCore.domain.CommentId;
-import com.example.project.emotionCore.domain.Episode;
-import com.example.project.emotionCore.domain.Series;
+import com.example.project.emotionCore.domain.*;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -21,5 +18,6 @@ public interface CommentRepository extends JpaRepository<Comment, CommentId>, Cu
 
     Optional<Comment> findByNumberAndSeriesIdAndCommentId(Long number, Long seriesId, Long commentId);
 
+    List<Comment> findByMember(Member member);
 
 }

--- a/src/main/java/com/example/project/emotionCore/Service/MineStorageService.java
+++ b/src/main/java/com/example/project/emotionCore/Service/MineStorageService.java
@@ -1,0 +1,26 @@
+package com.example.project.emotionCore.Service;
+
+import com.example.project.emotionCore.Repository.CommentRepository;
+import com.example.project.emotionCore.domain.Comment;
+import com.example.project.emotionCore.domain.Episode;
+import com.example.project.emotionCore.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MineStorageService {
+
+    private final CommentRepository commentRepository;
+
+    public List<Episode> getEpisodesByMember(Member member) {
+        List<Comment> comments = commentRepository.findByMember(member);
+        return comments.stream()
+                .map(Comment::getEpisode)
+                .distinct()
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/project/emotionCore/controller/MineStorageController.java
+++ b/src/main/java/com/example/project/emotionCore/controller/MineStorageController.java
@@ -1,0 +1,42 @@
+package com.example.project.emotionCore.controller;
+
+
+import com.example.project.emotionCore.Repository.MemberRepository;
+import com.example.project.emotionCore.Service.CommentService;
+import com.example.project.emotionCore.Service.CustomMemberDetail;
+import com.example.project.emotionCore.Service.MineStorageService;
+import com.example.project.emotionCore.domain.Episode;
+import com.example.project.emotionCore.domain.Member;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name="서재 API", description = "서재댓글부분 기능 담당")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/storage")
+public class MineStorageController {
+
+    private final MineStorageService mineStorageService;
+    private final MemberRepository memberRepository;
+
+    @Operation(summary="내가 작석한 댓글의 작품 조회")
+    @GetMapping("/comment")
+    public ResponseEntity<List<Episode>> getMyEpisodes(@AuthenticationPrincipal CustomMemberDetail customMemberDetail) {
+        long id=customMemberDetail.getId();
+        Member member = memberRepository.findById(id)
+                .orElseThrow(()->new RuntimeException("해당 회원을 찾을 수 없습니다."));
+
+        List<Episode> episodes = mineStorageService.getEpisodesByMember(member);
+
+        return ResponseEntity.ok(episodes);
+    }
+}


### PR DESCRIPTION
보안 강화 - 로그인한 사용자만 자신의 댓글을 단 작품 조회 가능하도록 변경

@AuthenticationPrincipal을 활용한 보안 강화

기존에는 @RequestParam Long MemberId로 사용자 ID를 직접 받았으나,
이제 로그인한 사용자 정보(CustomMemberDetail)를 기반으로 조회하도록 수정.
불법적인 ID 조작을 방지하여, 본인의 댓글이 달린 작품만 조회 가능.
응답 형식 개선
ResponseEntity<List<Episode>>로 감싸서 반환하도록 변경하여 유지보수성을 높임