### PR TITLE
좋아요 및 북마크 기능에서 @AuthenticationPrincipal 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,6 @@ dependencies {
 
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa' //jpa
-
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta' //querydsl start
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"

--- a/src/main/java/com/example/project/emotionCore/Service/BookMarkService.java
+++ b/src/main/java/com/example/project/emotionCore/Service/BookMarkService.java
@@ -24,9 +24,9 @@ public class BookMarkService {
     private final SeriesRepository seriesRepository;
 
     @Transactional
-    public void toggleBookMark(BookMarkRequestDTO bookMarkRequestDTO) {
+    public void toggleBookMark(Long id, BookMarkRequestDTO bookMarkRequestDTO) {
 
-        Member member = memberRepository.findById(bookMarkRequestDTO.getMemberId())
+        Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("멤버 id를 찾을 수 없습니다."));
 
         BookMark bookmark = null;
@@ -35,7 +35,7 @@ public class BookMarkService {
             Series series = seriesRepository.findById(bookMarkRequestDTO.getSeriesId())
                     .orElseThrow(() -> new EntityNotFoundException("시리즈 id를 찾을 수 없습니다."));
 
-            bookmark = bookMarkRepository.findByMemberIdAndSeriesId(member.getId(), (long) series.getId()).orElse(null);
+            bookmark = bookMarkRepository.findByMemberIdAndSeriesId(id, (long) series.getId()).orElse(null);
 
             if (bookmark != null) {
                 bookMarkRepository.delete(bookmark);

--- a/src/main/java/com/example/project/emotionCore/Service/LikeService.java
+++ b/src/main/java/com/example/project/emotionCore/Service/LikeService.java
@@ -24,9 +24,9 @@ public class LikeService {
     private final CommentRepository commentRepository;  // 댓글 레포지토리 추가
 
     @Transactional
-    public void toggleLike(LikeRequestDTO likeRequestDTO) {
+    public void toggleLike(Long id, LikeRequestDTO likeRequestDTO) {
 
-        Member member = memberRepository.findById(likeRequestDTO.getMemberId())
+        Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("멤버 id를 찾을 수 없습니다."));
 
         Like like = null;
@@ -36,7 +36,7 @@ public class LikeService {
             Series series = seriesRepository.findById(likeRequestDTO.getSeriesId())
                     .orElseThrow(() -> new EntityNotFoundException("시리즈 id를 찾을 수 없습니다."));
 
-            like = likeRepository.findByMemberIdAndSeriesId(member.getId(), (long) series.getId()).orElse(null);
+            like = likeRepository.findByMemberIdAndSeriesId(id, (long) series.getId()).orElse(null);
 
             if (like != null) {
                 likeRepository.delete(like);

--- a/src/main/java/com/example/project/emotionCore/controller/BookMarkController.java
+++ b/src/main/java/com/example/project/emotionCore/controller/BookMarkController.java
@@ -1,15 +1,15 @@
 package com.example.project.emotionCore.controller;
 
 import com.example.project.emotionCore.Service.BookMarkService;
-import com.example.project.emotionCore.Service.LikeService;
+import com.example.project.emotionCore.Service.CustomMemberDetail;
 import com.example.project.emotionCore.dto.BookMarkRequestDTO;
-import com.example.project.emotionCore.dto.LikeRequestDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,8 +24,9 @@ public class BookMarkController {
 
     @Operation(summary = "북마크 기능(일단 series에 관해서만)")
     @PostMapping()
-    public ResponseEntity<Void> toggleBookMark(@RequestBody @Valid BookMarkRequestDTO bookMarkRequestDTO) {
-        bookMarkService.toggleBookMark(bookMarkRequestDTO);
+    public ResponseEntity<Void> toggleBookMark(@AuthenticationPrincipal CustomMemberDetail customMemberDetail, @RequestBody @Valid BookMarkRequestDTO bookMarkRequestDTO) {
+        long id = customMemberDetail.getId();
+        bookMarkService.toggleBookMark(id, bookMarkRequestDTO);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/com/example/project/emotionCore/controller/LikeController.java
+++ b/src/main/java/com/example/project/emotionCore/controller/LikeController.java
@@ -1,5 +1,6 @@
 package com.example.project.emotionCore.controller;
 
+import com.example.project.emotionCore.Service.CustomMemberDetail;
 import com.example.project.emotionCore.Service.LikeService;
 import com.example.project.emotionCore.dto.LikeRequestDTO;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,6 +9,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "좋아요 API", description = "좋아요에 대한 기능 담당")
@@ -19,8 +21,9 @@ public class LikeController {
 
     @Operation(summary = "좋아요 기능(일단 series에 관해서만)")
     @PostMapping()
-    public ResponseEntity<Void> toggleLike(@RequestBody @Valid LikeRequestDTO likeRequestDTO) {
-        likeService.toggleLike(likeRequestDTO);
+    public ResponseEntity<Void> toggleLike(@AuthenticationPrincipal CustomMemberDetail customMemberDetail, @RequestBody @Valid LikeRequestDTO likeRequestDTO) {
+        Long id = customMemberDetail.getId();
+        likeService.toggleLike(id, likeRequestDTO);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/com/example/project/emotionCore/controller/WorkController.java
+++ b/src/main/java/com/example/project/emotionCore/controller/WorkController.java
@@ -109,15 +109,17 @@ public class WorkController {
 
     @Operation(summary = "(서재) 북마크 작품 반환")
     @GetMapping("/bookmark")
-    public ResponseEntity<List<SeriesPreviewDTO>> getAllSeriesByBookMark(@RequestParam int index, @RequestParam int num, @RequestParam long memberId) {
-        List<SeriesPreviewDTO> seriesPreviewDTOS = workService.getAllSeriesByBookMark(index, num, memberId);
+    public ResponseEntity<List<SeriesPreviewDTO>> getAllSeriesByBookMark(@RequestParam int index, @RequestParam int num, Authentication authentication) {
+        CustomMemberDetail customMemberDetail = (CustomMemberDetail) authentication.getPrincipal();
+        List<SeriesPreviewDTO> seriesPreviewDTOS = workService.getAllSeriesByBookMark(index, num, customMemberDetail.getId());
         return ResponseEntity.ok(seriesPreviewDTOS);
     }
 
     @Operation(summary = "(서재) 좋아요 작품 반환")
     @GetMapping("/like")
-    public ResponseEntity<List<SeriesPreviewDTO>> getAllSeriesByLike(@RequestParam int index, @RequestParam int num, @RequestParam long memberId) {
-        List<SeriesPreviewDTO> seriesPreviewDTOS = workService.getAllSeriesByLike(index, num, memberId);
+    public ResponseEntity<List<SeriesPreviewDTO>> getAllSeriesByLike(@RequestParam int index, @RequestParam int num, Authentication authentication) {
+        CustomMemberDetail customMemberDetail = (CustomMemberDetail) authentication.getPrincipal();
+        List<SeriesPreviewDTO> seriesPreviewDTOS = workService.getAllSeriesByLike(index, num, customMemberDetail.getId());
         return ResponseEntity.ok(seriesPreviewDTOS);
     }
 

--- a/src/main/java/com/example/project/emotionCore/dto/BookMarkRequestDTO.java
+++ b/src/main/java/com/example/project/emotionCore/dto/BookMarkRequestDTO.java
@@ -12,9 +12,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class BookMarkRequestDTO {
 
-    @Schema(description = "멤버Id", example = "1")
-    private Long memberId;
-
     @Schema(description = "시리즈Id", example = "1")
     private Long seriesId;
 }

--- a/src/main/java/com/example/project/emotionCore/dto/LikeRequestDTO.java
+++ b/src/main/java/com/example/project/emotionCore/dto/LikeRequestDTO.java
@@ -12,9 +12,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class LikeRequestDTO {
 
-    @Schema(description = "멤버Id", example = "1")
-    private Long memberId;
-
     @Schema(description = "시리즈Id", example = "1")
     private Long seriesId;
 


### PR DESCRIPTION
기존에 request body에서 memberId를 직접 받아오던 방식을 제거
@AuthenticationPrincipal을 활용하여 인증된 사용자 정보를 직접 조회하도록 수정