### PR TITLE
Feat : 소셜 로그인시 Author 객체 자동생성 로직 추가, 소셜 로그인시 동명이인이 존재한다면 0~9999의 랜덤한 숫자부여

### DIFF
--- a/src/main/java/com/example/project/emotionCore/service/NaverService.java
+++ b/src/main/java/com/example/project/emotionCore/service/NaverService.java
@@ -59,7 +59,6 @@ public class NaverService {
             throw new RuntimeException("Failed to get access token from Naver");
         }
     }
-
     // 네이버 API에서 사용자 정보 가져오기
     public Map<String, Object> getUserInfo(String accessToken) {
         String userInfoUrl = "https://openapi.naver.com/v1/nid/me";
@@ -76,4 +75,5 @@ public class NaverService {
             throw new RuntimeException("Failed to get user info from Naver");
         }
     }
+
 }

--- a/src/main/java/com/example/project/emotionCore/service/SearchWorkService.java
+++ b/src/main/java/com/example/project/emotionCore/service/SearchWorkService.java
@@ -20,15 +20,11 @@ public class SearchWorkService {
 
     @Transactional
     public void processSearch(String searchWord) {
-        // searchWord에 해당하는 엔티티를 검색
         SearchWork searchWork = searchWorkRepository.findBySearchWord(searchWord)
-                .orElseGet(() -> {
-                    // 없다면 새로 생성
-                    SearchWork newSearchWork = new SearchWork(searchWord);
-                    return searchWorkRepository.save(newSearchWork);
-                });
-
-        // 검색 횟수 증가
+                .orElse(null);
+        if (searchWork == null) {
+            searchWork = new SearchWork(searchWord); // count = 0 이어야 함
+        }
         searchWork.incrementSearchCount();
         searchWorkRepository.save(searchWork);
     }


### PR DESCRIPTION
### Feat

* **소셜 로그인 시 Author 자동 생성**

  * 소셜 로그인(카카오/네이버)으로 회원이 처음 가입할 경우
    `Member` 저장 직후 `Author` 엔티티를 자동으로 생성하여 1:1 매핑되도록 처리
  * `Author`는 `@MapsId` 구조를 사용해 `Member`의 id를 공유

* **닉네임 중복 방지 로직 추가**

  * 소셜 로그인 시, 이미 동일한 `username`(닉네임)이 존재하는 경우
  * 0\~9999 범위의 랜덤 숫자를 닉네임 뒤에 붙여 중복을 피하도록 개선
    예: `홍길동` → `홍길동42`


### 주요 효과

* 신규 소셜 가입 시 Author 엔티티를 별도 수동 생성할 필요가 없어짐
* 소셜 로그인 시 동명이인으로 인한 username 중복 문제 방지

---
### Issue
#21  => 1번 해결
